### PR TITLE
Update contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,10 @@ Bugcrowd welcomes community feedback and direct contributions to the Bugcrowd VR
 Please open your feedback as an **Issue** and label it as either a `bug` or an `enhancement`. Large or systemic changes should first be discussed in an Issue rather than be submitted as a pull request directly.
 
 Prior to opening a pull request please ensure your suggested changes pass specs. The repository uses [`rspec`](https://github.com/rspec/rspec) for spec running, run it with `bundle install && bundle exec rspec`.
+
+### Updating the VRT version
+When a new version of the VRT is released, we follow these steps:
+1. Add new submodule of the new version tag
+2. Cut new version of the gem
+3. Push new version to rubygems
+4. `bundle update vrt` in dependent applications

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,13 @@ Prior to opening a pull request please ensure your suggested changes pass specs.
 ### Updating the VRT version
 When a new version of the VRT is released, we follow these steps:
 1. Add new submodule of the new version tag
+    - `git submodule add git@github.com:bugcrowd/vulnerability-rating-taxonomy.git lib/data/X.X`
+    - `cd lib/data/X.X`
+    - `git checkout vX.X`
 2. Cut new version of the gem
+    - update Vrt::VERSION
+    - `rake build`
 3. Push new version to rubygems
-4. `bundle update vrt` in dependent applications
+    - `gem push OUTPUT_OF_RAKE_BUILD`
+4. Update dependent applications
+    - `bundle update vrt`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 <p align="center">
   <img src="https://badge.fury.io/rb/vrt.svg" />
-  <img src="https://badge.buildkite.com/96e360e0465da5f781829145aad202ebbdf3f8e7d296501c87.svg" />
+  <img src="https://badge.buildkite.com/96e360e0465da5f781829145aad202ebbdf3f8e7d296501c87.svg?branch=master" />
 </p>
 
 # VRT Ruby Wrapper


### PR DESCRIPTION
adds steps for what to do when we update the vrt version and need to cut a new version of the gem.

also updates the build status badge so that dev builds don't affect the status badge in the readme.