### PR TITLE
CVSS v3 mapping

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vrt (0.3.0)
+    vrt (0.3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ node.priority
 node.id
 
 node.name
+
+node.mappings
 ```
 
 ### If you need to deal with mappings between versions

--- a/lib/vrt.rb
+++ b/lib/vrt.rb
@@ -4,6 +4,7 @@
 
 require 'vrt/map'
 require 'vrt/node'
+require 'vrt/mapping'
 require 'vrt/cross_version_mapping'
 
 require 'date'
@@ -16,6 +17,7 @@ module VRT
                    'name' => 'Other',
                    'priority' => nil,
                    'type' => 'category' }.freeze
+  MAPPINGS = { cvss_v3: VRT::Mapping::CVSSv3 }.freeze
 
   @version_json = {}
   @last_update = {}
@@ -105,6 +107,10 @@ module VRT
     JSON.parse(json_pathname(version).read)['content']
   end
 
+  def mappings
+    @mappings ||= Hash[MAPPINGS.map { |name, klass| [name, klass.new] }]
+  end
+
   # Cache the VRT contents in-memory, so we're not hitting File I/O multiple times per
   # request that needs it.
   def reload!
@@ -112,6 +118,7 @@ module VRT
     versions
     get_json
     last_updated
+    mappings
   end
 
   # We separate unload! out, as we need to call it in test environments.
@@ -119,5 +126,6 @@ module VRT
     @versions = nil
     @version_json = {}
     @last_update = {}
+    @mappings = nil
   end
 end

--- a/lib/vrt.rb
+++ b/lib/vrt.rb
@@ -17,7 +17,7 @@ module VRT
                    'name' => 'Other',
                    'priority' => nil,
                    'type' => 'category' }.freeze
-  MAPPINGS = { cvss_v3: VRT::Mapping::CVSSv3 }.freeze
+  MAPPINGS = %i[cvss_v3].freeze
 
   @version_json = {}
   @last_update = {}
@@ -108,7 +108,7 @@ module VRT
   end
 
   def mappings
-    @mappings ||= Hash[MAPPINGS.map { |name, klass| [name, klass.new] }]
+    @mappings ||= Hash[MAPPINGS.map { |name| [name, VRT::Mapping.new(name)] }]
   end
 
   # Cache the VRT contents in-memory, so we're not hitting File I/O multiple times per

--- a/lib/vrt/mapping.rb
+++ b/lib/vrt/mapping.rb
@@ -1,7 +1,7 @@
 module VRT
   class Mapping
     def initialize(scheme)
-      @scheme = scheme
+      @scheme = scheme.to_s
       load_mappings
     end
 
@@ -57,12 +57,6 @@ module VRT
         mapping.each_with_object({}) { |(key, value), acc| acc[key] = key_by_id(value) }
       else
         mapping
-      end
-    end
-
-    class CVSSv3 < Mapping
-      def initialize
-        super('cvss_v3')
       end
     end
   end

--- a/lib/vrt/mapping.rb
+++ b/lib/vrt/mapping.rb
@@ -1,0 +1,52 @@
+module VRT
+  class Mapping
+    def initialize(scheme)
+      @scheme = scheme
+      @mapping = load_mapping
+    end
+
+    # returns the most specific value provided in the mapping file
+    def get(id_list)
+      mapping = @mapping['content']
+      best_guess = nil
+      id_list.each do |id|
+        entry = mapping[id]
+        break unless entry # mapping file doesn't go this deep, return previous value
+        best_guess = entry[@scheme] if entry[@scheme]
+        # use the children mapping for the next iteration
+        mapping = entry['children'] || {}
+      end
+      best_guess
+    end
+
+    private
+
+    def load_mapping
+      filename = VRT::DIR.join(VRT.current_version, 'mappings', "#{@scheme}.json")
+      mapping = File.file?(filename) ? JSON.parse(File.read(filename)) : {}
+      mapping['content'] = key_by_id(mapping['content'])
+      mapping
+    end
+
+    # Converts arrays to hashes keyed by the id attribute (as a symbol) for easier lookup. So
+    #     [{'id': 'one', 'foo': 'bar'}, {'id': 'two', 'foo': 'baz'}]
+    # becomes
+    #     {one: {'id': 'one', 'foo': 'bar'}, two: {'id': 'two', 'foo': 'baz'}}
+    def key_by_id(mapping)
+      case mapping
+      when Array
+        mapping.each_with_object({}) { |entry, acc| acc[entry['id'].to_sym] = key_by_id(entry) }
+      when Hash
+        mapping.each_with_object({}) { |(key, value), acc| acc[key] = key_by_id(value) }
+      else
+        mapping
+      end
+    end
+
+    class CVSSv3 < Mapping
+      def initialize
+        super('cvss_v3')
+      end
+    end
+  end
+end

--- a/lib/vrt/mapping.rb
+++ b/lib/vrt/mapping.rb
@@ -10,7 +10,7 @@ module VRT
     # if no mapping file exists for the given version, the mapping file for the earliest version available will be used
     def get(id_list, version)
       # update the vrt id to the first version we have a mapping file for
-      unless @mappings.has_key?(version)
+      unless @mappings.key?(version)
         id_list = VRT.find_node(vrt_id: id_list.join('.'), preferred_version: @min_version).id_list
         version = @min_version
       end

--- a/lib/vrt/node.rb
+++ b/lib/vrt/node.rb
@@ -24,7 +24,7 @@ module VRT
     end
 
     def cvss_v3
-      VRT.mappings[:cvss_v3].get(id_list)
+      VRT.mappings[:cvss_v3].get(id_list, @version)
     end
 
     def id_list

--- a/lib/vrt/node.rb
+++ b/lib/vrt/node.rb
@@ -23,8 +23,8 @@ module VRT
       id_list.join('.')
     end
 
-    def cvss_v3
-      VRT.mappings[:cvss_v3].get(id_list, @version)
+    def mappings
+      Hash[VRT.mappings.map { |name, map| [name, map.get(id_list, @version)] }]
     end
 
     def id_list

--- a/lib/vrt/node.rb
+++ b/lib/vrt/node.rb
@@ -20,7 +20,15 @@ module VRT
     end
 
     def construct_vrt_id
-      parent ? "#{parent.qualified_vrt_id}.#{id}" : id.to_s
+      id_list.join('.')
+    end
+
+    def cvss_v3
+      VRT.mappings[:cvss_v3].get(id_list)
+    end
+
+    def id_list
+      parent ? parent.id_list << id : [id]
     end
 
     # Since this object contains references to parent and children,

--- a/lib/vrt/version.rb
+++ b/lib/vrt/version.rb
@@ -1,3 +1,3 @@
 module Vrt
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end

--- a/spec/sample_vrt/2.0/mappings/cvss_v3.json
+++ b/spec/sample_vrt/2.0/mappings/cvss_v3.json
@@ -1,0 +1,69 @@
+{
+  "metadata": {
+    "default": "default"
+  },
+  "content": [
+    {
+      "id": "server_security_misconfiguration",
+      "cvss_v3": "a",
+      "children": [
+        {
+          "id": "unsafe_cross_origin_resource_sharing",
+          "cvss_v3": "b"
+        },
+        {
+          "id": "ssl_attack_breach_poodle_etc",
+          "cvss_v3": "c"
+        },
+        {
+          "id": "using_default_credentials",
+          "cvss_v3": "d"
+        },
+        {
+          "id": "misconfigured_dns",
+          "cvss_v3": "e"
+        }
+      ]
+    },
+    {
+      "id": "server_side_injection",
+      "children": [
+        {
+          "id": "file_inclusion",
+          "cvss_v3": "f"
+        },
+        {
+          "id": "remote_code_execution_rce",
+          "cvss_v3": "g"
+        },
+        {
+          "id": "sql_injection",
+          "cvss_v3": "h"
+        }
+      ]
+    },
+    {
+      "id": "unvalidated_redirects_and_forwards",
+      "cvss_v3": "i",
+      "children": [
+        {
+          "id": "open_redirect",
+          "children": [
+            {
+              "id": "get_based",
+              "cvss_v3": "j"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "dumb_v2_category",
+      "cvss_v3": "k"
+    },
+    {
+      "id": "insecure_data_storage",
+      "cvss_v3": "l"
+    }
+  ]
+}

--- a/spec/sample_vrt/999.999/mappings/cvss_v3.json
+++ b/spec/sample_vrt/999.999/mappings/cvss_v3.json
@@ -1,0 +1,141 @@
+{
+  "metadata": {
+    "default": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+  },
+  "content": [
+    {
+      "id": "server_security_misconfiguration",
+      "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "children": [
+        {
+          "id": "unsafe_cross_origin_resource_sharing",
+          "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        },
+        {
+          "id": "ssl_attack_breach_poodle_etc",
+          "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        },
+        {
+          "id": "using_default_credentials",
+          "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+        },
+        {
+          "id": "misconfigured_dns",
+          "cvss_v3": "AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:L"
+        }
+      ]
+    },
+    {
+      "id": "server_side_injection",
+      "children": [
+        {
+          "id": "file_inclusion",
+          "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L"
+        },
+        {
+          "id": "remote_code_execution_rce",
+          "cvss_v3": "AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+        },
+        {
+          "id": "sql_injection",
+          "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N"
+        }
+      ]
+    },
+    {
+      "id": "unvalidated_redirects_and_forwards",
+      "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N",
+      "children": [
+        {
+          "id": "open_redirect",
+          "children": [
+            {
+              "id": "get_based",
+              "cvss_v3": "AV:N/AC:L/PR:L/UI:R/S:U/C:N/I:L/A:N"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "broken_authentication_and_session_management",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "insecure_direct_object_references_idor",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "sensitive_data_exposure",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "cross_site_scripting_xss",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "missing_function_level_access_control",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "cross_site_request_forgery_csrf",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "application_level_denial_of_service_dos",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "external_behavior",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "insufficient_security_configurability",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "using_components_with_known_vulnerabilities",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "insecure_data_storage",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "lack_of_binary_hardening",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "insecure_data_transport",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "insecure_os_firmware",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "broken_cryptography",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "privacy_concerns",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "network_security_misconfiguration",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "mobile_security_misconfiguration",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "client_side_injection",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    },
+    {
+      "id": "vrt_category_only_in_test",
+      "cvss_v3": "AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N"
+    }
+  ]
+}

--- a/spec/vrt/mappings_spec.rb
+++ b/spec/vrt/mappings_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+describe VRT::Mapping::CVSSv3 do
+  let(:vrt) { VRT }
+  let(:cvss) { described_class.new }
+
+  describe '#get' do
+    subject { cvss.get(id_list, version) }
+
+    context 'when cvss_v3 on leaf node' do
+      let(:id_list) { %i[unvalidated_redirects_and_forwards open_redirect get_based] }
+      let(:version) { '2.0' }
+
+      it { is_expected.to eq('j') }
+    end
+
+    context 'when cvss_v3 on internal node' do
+      let(:id_list) { %i[server_security_misconfiguration unsafe_cross_origin_resource_sharing critical_impact] }
+      let(:version) { '2.0' }
+
+      it { is_expected.to eq('b') }
+    end
+
+    context 'when cvss_v3 on root node with children' do
+      let(:id_list) { %i[server_security_misconfiguration unsafe_file_upload no_antivirus] }
+      let(:version) { '2.0' }
+
+      it { is_expected.to eq('a') }
+    end
+
+    context 'when cvss_v3 on root node without children' do
+      let(:id_list) { %i[insecure_data_storage] }
+      let(:version) { '2.0' }
+
+      it { is_expected.to eq('l') }
+    end
+
+    context 'when other' do
+      let(:id_list) { %i[other] }
+      let(:version) { '2.0' }
+
+      it { is_expected.to eq('default') }
+    end
+
+    context 'when newer version' do
+      let(:id_list) { %i[unvalidated_redirects_and_forwards open_redirect get_based] }
+      let(:version) { '999.999' }
+
+      it { is_expected.to eq('AV:N/AC:L/PR:L/UI:R/S:U/C:N/I:L/A:N') }
+    end
+
+    context 'when version predates the mapping' do
+      context 'but id still exists' do
+        let(:id_list) { %i[server_security_misconfiguration misconfigured_dns] }
+        let(:version) { '1.0' }
+
+        it 'gets the mapping from earliest version with mapping' do
+          is_expected.to eq('e')
+        end
+      end
+
+      context 'and id is deprecated' do
+        let(:id_list) { %i[unvalidated_redirects_and_forwards open_redirect get_based_authenticated] }
+        let(:version) { '1.0' }
+
+        it 'follows deprecated_node_mapping' do
+          is_expected.to eq('j')
+        end
+      end
+    end
+  end
+end

--- a/spec/vrt/mappings_spec.rb
+++ b/spec/vrt/mappings_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe VRT::Mapping::CVSSv3 do
+describe VRT::Mapping do
   let(:vrt) { VRT }
-  let(:cvss) { described_class.new }
+  let(:cvss) { described_class.new(:cvss_v3) }
 
   describe '#get' do
     subject { cvss.get(id_list, version) }

--- a/spec/vrt/node_spec.rb
+++ b/spec/vrt/node_spec.rb
@@ -39,6 +39,21 @@ describe VRT::Node do
     end
   end
 
+  describe '#mappings' do
+    subject(:mappings) { VRT::Map.new(version).find_node(id).mappings }
+
+    let(:version) { '2.0' }
+    let(:id) { 'server_security_misconfiguration.unsafe_cross_origin_resource_sharing.high_impact' }
+
+    it 'returns a hash with the correct keys' do
+      expect(mappings.keys).to eq(VRT::MAPPINGS)
+    end
+
+    it 'has the right values' do
+      expect(mappings).to include(cvss_v3: 'b')
+    end
+  end
+
   describe '#as_json' do
     subject(:node_hash) { VRT::Map.new(version).find_node(id).as_json }
 


### PR DESCRIPTION
Add functionality to use the CVSS mapping being added in https://github.com/bugcrowd/vulnerability-rating-taxonomy/pull/86.

#### To test
1. ~check out a local copy of that PR~
2. ~`cd vrt-ruby/lib/data`~
3. ~`ln -s path/to/vulnerability-rating-taxonomy 1.3`~
4. `irb -I lib -r vrt.rb`
5. `VRT.find_node(vrt_id: 'server_side_injection.file_inclusion.local').cvss_v3`

#### TODO
- [x] Handle previous versions
- [x] specs
- [x] merge https://github.com/bugcrowd/vulnerability-rating-taxonomy/pull/86
- [x] release vulnerability-rating-taxonomy v1.3
- [x] Add vrt v1.3 submodule to this repo