### PR TITLE
Make VRT.find_node work without the version parameter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ Style/FrozenStringLiteralComment:
 
 Metrics/LineLength:
   Max: 120
+  IgnoreCopDirectives: true
 
 Metrics/BlockLength:
   ExcludedMethods:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ match for a node under any version and has options to specify a preferred versio
 # Find a node in a given preferred version that best maps to the given id
 VRT.find_node(
   vrt_id: 'social_engineering',
-  version: '1.0',
   preferred_version: '1.1'
 )
 # returns 'other'
@@ -82,7 +81,6 @@ VRT.find_node(
 # Aggregate vulnerabilities by category
 VRT.find_node(
   vrt_id: vrt_id,
-  version: vrt_version,
   max_depth: 'category'
 )
 

--- a/lib/vrt.rb
+++ b/lib/vrt.rb
@@ -64,20 +64,20 @@ module VRT
   # the appropriate deprecated mapping. If neither is found it will walk up the tree to find a
   # valid parent node before giving up and returning nil.
   #
-  # @param [String] A valid vrt_id
-  # @param [String] (Optional - recommended) A valid vrt_version that the vrt_id exists in
-  # @param [string] (Optional) The preferred new vrt_version to find a match in
-  # @param [String] (Optional) The maximum depth to match in
+  # @param [String] vrt_id A valid vrt_id
+  # @param [string] preferred_version (Optional) The preferred vrt_version of the returned node
+  #   (defaults to current_version)
+  # @param [String] max_depth (Optional) The maximum depth to match in
+  # @param [String] version (deprecated) This parameter is no longer used
   # @return [VRT::Node|Nil] A valid VRT::Node object or nil if no best match could be found
-  def find_node(vrt_id:, version: nil, preferred_version: nil, max_depth: 'variant')
+  def find_node(vrt_id:, preferred_version: nil, max_depth: 'variant', version: nil) # rubocop:disable Lint/UnusedMethodArgument
     new_version = preferred_version || current_version
     if Map.new(new_version).valid?(vrt_id)
       Map.new(new_version).find_node(vrt_id, max_depth: max_depth)
     elsif deprecated_node?(vrt_id)
       find_deprecated_node(vrt_id, preferred_version, max_depth)
     else
-      return nil unless version
-      find_valid_parent_node(vrt_id, version, new_version, max_depth)
+      find_valid_parent_node(vrt_id, new_version, max_depth)
     end
   end
 

--- a/lib/vrt/cross_version_mapping.rb
+++ b/lib/vrt/cross_version_mapping.rb
@@ -31,14 +31,14 @@ module VRT
       VRT::Map.new(new_version).find_node(node_id, max_depth: max_depth)
     end
 
-    def find_valid_parent_node(vrt_id, old_version, new_version, max_depth)
-      old_node = VRT::Map.new(old_version).find_node(vrt_id)
+    def find_valid_parent_node(vrt_id, new_version, max_depth)
       new_map = VRT::Map.new(new_version)
       if new_map.valid?(vrt_id)
         new_map.find_node(vrt_id, max_depth: max_depth)
       else
-        return nil if old_node.parent.nil?
-        find_valid_parent_node(old_node.parent.qualified_vrt_id, old_version, new_version, max_depth)
+        parent = vrt_id.split('.')[0..-2].join('.')
+        return nil if parent.empty?
+        find_valid_parent_node(parent, new_version, max_depth)
       end
     end
   end

--- a/spec/sample_vrt/2.0/mappings/cvss_v3.json
+++ b/spec/sample_vrt/2.0/mappings/cvss_v3.json
@@ -64,6 +64,15 @@
     {
       "id": "insecure_data_storage",
       "cvss_v3": "l"
+    },
+    {
+      "id": "broken_authentication_and_session_management",
+      "children": [
+        {
+          "id": "authentication_bypass",
+          "cvss_v3": "m"
+        }
+      ]
     }
   ]
 }

--- a/spec/sample_vrt/2.0/vulnerability-rating-taxonomy.json
+++ b/spec/sample_vrt/2.0/vulnerability-rating-taxonomy.json
@@ -155,6 +155,19 @@
       ]
     },
     {
+      "id": "broken_authentication_and_session_management",
+      "name": "Broken Authentication and Session Management",
+      "type": "category",
+      "children": [
+        {
+          "id": "authentication_bypass",
+          "name": "Authentication Bypass",
+          "type": "subcategory",
+          "priority": 1
+        }
+      ]
+    },
+    {
       "id": "dumb_v2_category",
       "name": "Dumb V2 Category",
       "type": "category",

--- a/spec/vrt/mappings_spec.rb
+++ b/spec/vrt/mappings_spec.rb
@@ -67,6 +67,15 @@ describe VRT::Mapping do
           is_expected.to eq('j')
         end
       end
+
+      context 'and id is deprecated with valid parent' do
+        let(:id_list) { %i[broken_authentication_and_session_management authentication_bypass horizontal] }
+        let(:version) { '1.0' }
+
+        it 'finds valid parent' do
+          is_expected.to eq('m')
+        end
+      end
     end
   end
 end

--- a/spec/vrt_spec.rb
+++ b/spec/vrt_spec.rb
@@ -58,13 +58,11 @@ describe VRT do
     subject(:found_node) do
       described_class.find_node(
         vrt_id: vrt_id,
-        version: old_version,
         preferred_version: new_version,
         max_depth: max_depth
       )
     end
 
-    let(:old_version) { '1.0' }
     let(:new_version) { nil }
     let(:max_depth) { 'variant' }
 


### PR DESCRIPTION
I was confused what the version parameter to `VRT.find_node` was for when I was writing the mapping code and so didn't pass it in. This means mappings don't work correctly for some deprecated nodes. Rather than just passing in the argument (which would also work), it appears that parameter is only used to find a `vrt_id`s parent, which we can do with basic string manipulation. On the assumption that someone else later will also forget to pass in the argument, this deprecates the parameter.

I also added the rubocop option to ignore `rubocop:disable` comments that take a line over 120 characters. IMO this is cleaner than wrapping the function in `rubocop:disable`/`rubocop:enable`.