### PR TITLE
Split up vrt id token validation and determining if its a valid vrt in the current VRT schema

### DIFF
--- a/lib/vrt/map.rb
+++ b/lib/vrt/map.rb
@@ -26,7 +26,7 @@ module VRT
     end
 
     def get_lineage(string, max_depth: 'variant')
-      @_lineages[string] ||= construct_lineage(string, max_depth)
+      @_lineages[string + max_depth] ||= construct_lineage(string, max_depth)
     end
 
     # Returns list of top level categories in the shape:

--- a/lib/vrt/map.rb
+++ b/lib/vrt/map.rb
@@ -18,15 +18,15 @@ module VRT
     end
 
     def find_node(string, max_depth: 'variant')
-      @found_nodes[string + max_depth] ||= walk_node_tree(string, max_depth: max_depth)
+      @_found_nodes[string + max_depth] ||= walk_node_tree(string, max_depth: max_depth)
     end
 
     def valid?(vrt_id)
-      valid_identifier?(vrt_id) && find_node(vrt_id)
+      @_valid_vrt_ids[vrt_id] ||= valid_identifier?(vrt_id) && find_node(vrt_id)
     end
 
     def get_lineage(string, max_depth: 'variant')
-      @lineages[string] ||= construct_lineage(string, max_depth)
+      @_lineages[string] ||= construct_lineage(string, max_depth)
     end
 
     # Returns list of top level categories in the shape:
@@ -40,9 +40,9 @@ module VRT
 
     private
 
-    def valid_identifier?(id)
+    def valid_identifier?(vrt_id)
       # At least one string of lowercase or _, plus up to 2 more with stops
-      id =~ /other|\A[a-z_]+(\.[a-z_]+){0,2}\z/
+      @_valid_identifiers[vrt_id] ||= vrt_id =~ /other|\A[a-z_]+(\.[a-z_]+){0,2}\z/
     end
 
     def construct_lineage(string, max_depth)

--- a/lib/vrt/map.rb
+++ b/lib/vrt/map.rb
@@ -19,13 +19,8 @@ module VRT
       @found_nodes[string + max_depth] ||= walk_node_tree(string, max_depth: max_depth)
     end
 
-    def valid?(node)
-      return true if node == 'other'
-      # At least one string of lowercase or _, plus up to 2 more with stops
-      return false unless node =~ /\A[a-z_]+(\.[a-z_]+){0,2}\z/
-      found_node = find_node(node)
-      return false unless found_node
-      true
+    def valid?(vrt_id)
+      valid_identifier?(vrt_id) && find_node(vrt_id)
     end
 
     def get_lineage(string, max_depth: 'variant')
@@ -43,6 +38,11 @@ module VRT
 
     private
 
+    def valid_identifier?(id)
+      # At least one string of lowercase or _, plus up to 2 more with stops
+      id =~ /other|\A[a-z_]+(\.[a-z_]+){0,2}\z/
+    end
+
     def construct_lineage(string, max_depth)
       lineage = ''
       walk_node_tree(string, max_depth: max_depth) do |ids, node, level|
@@ -54,7 +54,6 @@ module VRT
 
     def walk_node_tree(string, max_depth: 'variant')
       id_tokens = string.split('.').map(&:to_sym)
-      return nil if id_tokens.size > 3
       ids = id_tokens.take(DEPTH_MAP[max_depth])
       node = @structure[ids[0]]
       ids.each_index do |idx|

--- a/lib/vrt/map.rb
+++ b/lib/vrt/map.rb
@@ -11,8 +11,10 @@ module VRT
     def initialize(version = nil)
       @version = version || VRT.current_version
       @structure = build_structure
-      @found_nodes = {}
-      @lineages = {}
+      @_found_nodes = {}
+      @_lineages = {}
+      @_valid_vrt_ids = {}
+      @_valid_identifiers = {}
     end
 
     def find_node(string, max_depth: 'variant')

--- a/lib/vrt/map.rb
+++ b/lib/vrt/map.rb
@@ -22,7 +22,7 @@ module VRT
     end
 
     def valid?(vrt_id)
-      @_valid_vrt_ids[vrt_id] ||= valid_identifier?(vrt_id) && find_node(vrt_id)
+      @_valid_vrt_ids[vrt_id] ||= valid_identifier?(vrt_id) && !find_node(vrt_id).nil?
     end
 
     def get_lineage(string, max_depth: 'variant')

--- a/lib/vrt/map.rb
+++ b/lib/vrt/map.rb
@@ -46,8 +46,10 @@ module VRT
     end
 
     def construct_lineage(string, max_depth)
+      return unless valid_identifier?(string)
       lineage = ''
       walk_node_tree(string, max_depth: max_depth) do |ids, node, level|
+        return unless node
         lineage += node.name
         lineage += ' > ' unless level == ids.length
       end


### PR DESCRIPTION
Base branch #11 

1. Added some caching (prepended the cache ivar names for best practice)
2. Split up the `valid?` method into:
    a. Token validation
    b. making sure it's a valid node W.R.T. the schema
3. Make sure lineages return `nil` when the vrt id is invalid rather than throwing an exception

The caching here is probably not so important given that most of the time we are creating entirely new `Vrt::Map` instances. Maybe there's a case to be made that the VRT singleton should have a memo map of all the `VRT::Map`'s for each version (or at least start pre-warmed with the current version)? Either way I'd address separately.