### PR TITLE
Add safeties on release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,6 @@ When a new version of the VRT is released, we follow these steps:
     - `git checkout vX.X`
 2. Cut new version of the gem
     - update Vrt::VERSION
-    - `rake build`
-3. Push new version to rubygems
-    - `gem push OUTPUT_OF_RAKE_BUILD`
-4. Update dependent applications
+    - `rake release`
+3. Update dependent applications
     - `bundle update vrt`

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,11 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec
+
+desc 'Override our build task to ensure VRT git submodules are present'
+task 'build' do
+  submodule_status = `git submodule init && git submodule update`
+  unless submodule_status.empty?
+    raise 'git submodules were not up-to-date. Please rebuild!'
+  end
+end

--- a/lib/vrt/version.rb
+++ b/lib/vrt/version.rb
@@ -1,3 +1,3 @@
 module Vrt
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.4.0'.freeze
 end


### PR DESCRIPTION
It turns out `rake release` does a lot of the work of releasing a gem for us ([see here](https://github.com/bundler/bundler/blob/5566b687c135178561f7524d3a5cb68fee56e416/lib/bundler/gem_helper.rb#L57)); specifically, it will alert us if our working tree is dirty, tag the current version (based on the Gemspec), push the tag, and if all that succeeds, push up to rubygems.

In addition to that, we want to make sure our git submodules have been initialized/updated.

Unfortunately bundler doesn't give us an easy way to hook a new rake task before either `rake build` or `rake release`, but we can define an additional `build` task in our Rakefile which can raise an error if either `git submodule init` or `git submodule update` returned any string (which would indicate that our build step failed)

Definitely open to suggestions on how to improve this further.