### PR TITLE
Allow VRT ids to contain numbers

### DIFF
--- a/lib/vrt/map.rb
+++ b/lib/vrt/map.rb
@@ -42,7 +42,7 @@ module VRT
 
     def valid_identifier?(vrt_id)
       # At least one string of lowercase or _, plus up to 2 more with stops
-      @_valid_identifiers[vrt_id] ||= vrt_id =~ /other|\A[a-z_]+(\.[a-z_]+){0,2}\z/
+      @_valid_identifiers[vrt_id] ||= vrt_id =~ /other|\A[a-z_\d]+(\.[a-z_\d]+){0,2}\z/
     end
 
     def construct_lineage(string, max_depth)

--- a/spec/vrt/map_spec.rb
+++ b/spec/vrt/map_spec.rb
@@ -121,5 +121,10 @@ describe VRT::Map do
       let(:string) { 'server_security_misconfiguration.meep_meep_meep' }
       it { is_expected.to be_falsey }
     end
+
+    context 'when contains numbers' do
+      let(:string) { 'sensitive_data_exposure.token_leakage_via_referer.untrusted_3rd_party' }
+      it { is_expected.to be_truthy }
+    end
   end
 end


### PR DESCRIPTION
The current validation fails on validating VRT IDs that contain numbers
which breaks on the current version of VRT. This commit loosens the
validation on IDs to allow digits.

I'd like to do a release of this ASAP.