### PR TITLE
Add VRT 1.4 and handling for CWE and Remediation Advice mappings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "lib/data/1.3.1"]
 	path = lib/data/1.3.1
 	url = git@github.com:bugcrowd/vulnerability-rating-taxonomy.git
+[submodule "lib/data/1.4"]
+	path = lib/data/1.4
+	url = git@github.com:bugcrowd/vulnerability-rating-taxonomy.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 - VRT 1.4 data
 - Support for mappings with `keys` metadata
-- VRT to CWE mapping
-- VRT to Bugcrowd Remediation Advice mapping
+- CWE mapping
+- Bugcrowd Remediation Advice mapping
 
 ### Changed
-- Mappings with array and hash values now caolesce downwards.
+- Mappings with array values now caolesce downwards.
   Child VRT nodes will include values from parent nodes if a mapping
-  provides data for a node in an array or a hash.
+  provides node data as an array.
 
 ## [v0.4.6](https://github.com/bugcrowd/vrt-ruby/compare/v0.4.5...v0.4.6) - 2018-02-05
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
-
-### Removed
+- VRT 1.4 data
+- Support for mappings with `keys` metadata
+- VRT to CWE mapping
+- VRT to Bugcrowd Remediation Advice mapping
 
 ### Changed
+- Mappings with array and hash values now caolesce downwards.
+  Child VRT nodes will include values from parent nodes if a mapping
+  provides data for a node in an array or a hash.
 
 ## [v0.4.6](https://github.com/bugcrowd/vrt-ruby/compare/v0.4.5...v0.4.6) - 2018-02-05
 ### Changed

--- a/lib/vrt.rb
+++ b/lib/vrt.rb
@@ -17,7 +17,7 @@ module VRT
                    'name' => 'Other',
                    'priority' => nil,
                    'type' => 'category' }.freeze
-  MAPPINGS = %i[cvss_v3 remediation_advice].freeze
+  MAPPINGS = %i[cvss_v3 remediation_advice cwe].freeze
 
   @version_json = {}
   @last_update = {}

--- a/lib/vrt.rb
+++ b/lib/vrt.rb
@@ -17,7 +17,7 @@ module VRT
                    'name' => 'Other',
                    'priority' => nil,
                    'type' => 'category' }.freeze
-  MAPPINGS = %i[cvss_v3].freeze
+  MAPPINGS = %i[cvss_v3 remediation_advice].freeze
 
   @version_json = {}
   @last_update = {}

--- a/lib/vrt/mapping.rb
+++ b/lib/vrt/mapping.rb
@@ -14,19 +14,25 @@ module VRT
         id_list = VRT.find_node(vrt_id: id_list.join('.'), preferred_version: @min_version).id_list
         version = @min_version
       end
-
-      # iterate through the id components, keeping track of where we are in the mapping file
-      # and the most specific mapped value found so far
       mapping = @mappings[version]['content']
-      best_guess = @mappings[version]['metadata']['default']
-      id_list.each do |id|
-        entry = mapping[id]
-        break unless entry # mapping file doesn't go this deep, return previous value
-        best_guess = entry[@scheme] if entry[@scheme]
-        # use the children mapping for the next iteration
-        mapping = entry['children'] || {}
+      default = @mappings[version]['metadata']['default']
+      keys = @mappings[version]['metadata']['keys']
+      if keys
+        # Convert mappings with multiple keys to live under a single
+        # top-level key. Remediation advice has keys 'remediation_advice'
+        # and 'references' so we convert it to look like
+        # { remediation_advice: { remediation_advice: 'advice', references: [...] } }
+        keys.each_with_object({}) do |key, acc|
+          acc[key.to_sym] = get_key(
+            id_list: id_list,
+            mapping: mapping,
+            key: key,
+            default: default&.try(:[], key)
+          )
+        end
+      else
+        get_key(id_list: id_list, mapping: mapping, key: @scheme, default: default)
       end
-      best_guess
     end
 
     private
@@ -50,13 +56,36 @@ module VRT
     # becomes
     #     {one: {'id': 'one', 'foo': 'bar'}, two: {'id': 'two', 'foo': 'baz'}}
     def key_by_id(mapping)
-      case mapping
-      when Array
+      if mapping.is_a?(Array) && mapping.first.is_a?(Hash) && mapping.first.key?('id')
         mapping.each_with_object({}) { |entry, acc| acc[entry['id'].to_sym] = key_by_id(entry) }
-      when Hash
+      elsif mapping.is_a?(Hash)
         mapping.each_with_object({}) { |(key, value), acc| acc[key] = key_by_id(value) }
       else
         mapping
+      end
+    end
+
+    def get_key(id_list:, mapping:, key:, default:)
+      # iterate through the id components, keeping track of where we are in the mapping file
+      # and the most specific mapped value found so far
+      best_guess = default
+      id_list.each do |id|
+        entry = mapping[id]
+        break unless entry # mapping file doesn't go this deep, return previous value
+        best_guess = merge_collections(best_guess, entry[key]) if entry[key]
+        # use the children mapping for the next iteration
+        mapping = entry['children'] || {}
+      end
+      best_guess
+    end
+
+    def merge_collections(previous_value, new_value)
+      if previous_value.is_a?(Array) && new_value.is_a?(Array)
+        new_value + previous_value
+      elsif previous_value.is_a?(Hash) && new_value.is_a?(Hash)
+        previous_value.merge(new_value)
+      else
+        new_value
       end
     end
   end

--- a/lib/vrt/mapping.rb
+++ b/lib/vrt/mapping.rb
@@ -81,7 +81,7 @@ module VRT
 
     def merge_collections(previous_value, new_value)
       if previous_value.is_a?(Array) && new_value.is_a?(Array)
-        new_value + previous_value
+        new_value | previous_value
       elsif previous_value.is_a?(Hash) && new_value.is_a?(Hash)
         previous_value.merge(new_value)
       else

--- a/lib/vrt/mapping.rb
+++ b/lib/vrt/mapping.rb
@@ -21,7 +21,7 @@ module VRT
         # Convert mappings with multiple keys to live under a single
         # top-level key. Remediation advice has keys 'remediation_advice'
         # and 'references' so we convert it to look like
-        # { remediation_advice: { remediation_advice: 'advice', references: [...] } }
+        # { remediation_advice: { remediation_advice: '...', references: [...] } }
         keys.each_with_object({}) do |key, acc|
           acc[key.to_sym] = get_key(
             id_list: id_list,
@@ -72,18 +72,16 @@ module VRT
       id_list.each do |id|
         entry = mapping[id]
         break unless entry # mapping file doesn't go this deep, return previous value
-        best_guess = merge_collections(best_guess, entry[key]) if entry[key]
+        best_guess = merge_arrays(best_guess, entry[key]) if entry[key]
         # use the children mapping for the next iteration
         mapping = entry['children'] || {}
       end
       best_guess
     end
 
-    def merge_collections(previous_value, new_value)
+    def merge_arrays(previous_value, new_value)
       if previous_value.is_a?(Array) && new_value.is_a?(Array)
         new_value | previous_value
-      elsif previous_value.is_a?(Hash) && new_value.is_a?(Hash)
-        previous_value.merge(new_value)
       else
         new_value
       end

--- a/lib/vrt/mapping.rb
+++ b/lib/vrt/mapping.rb
@@ -18,7 +18,7 @@ module VRT
       default = @mappings[version]['metadata']['default']
       keys = @mappings[version]['metadata']['keys']
       if keys
-        # Convert mappings with multiple keys to live under a single
+        # Convert mappings with multiple keys to be nested under a single
         # top-level key. Remediation advice has keys 'remediation_advice'
         # and 'references' so we convert it to look like
         # { remediation_advice: { remediation_advice: '...', references: [...] } }

--- a/spec/sample_vrt/2.0/mappings/cwe.json
+++ b/spec/sample_vrt/2.0/mappings/cwe.json
@@ -1,0 +1,60 @@
+{
+  "metadata": {
+    "default": ["CWE-2000"]
+  },
+  "content": [
+    {
+      "id": "server_security_misconfiguration",
+      "cwe": ["CWE-933"],
+      "children": [
+        {
+          "id": "unsafe_cross_origin_resource_sharing",
+          "cwe": ["CWE-942"]
+        },
+        {
+          "id": "path_traversal",
+          "cwe": ["CWE-22", "CWE-73"]
+        },
+        {
+          "id": "directory_listing_enabled",
+          "cwe": ["CWE-548"]
+        },
+        {
+          "id": "ssl_attack_breach_poodle_etc",
+          "cwe": ["CWE-310"]
+        },
+        {
+          "id": "using_default_credentials",
+          "cwe": ["CWE-255", "CWE-521"]
+        },
+        {
+          "id": "misconfigured_dns",
+          "children": [
+            {
+              "id": "zone_transfer",
+              "cwe": ["CWE-669"]
+            }
+          ]
+        },
+        {
+          "id": "dbms_misconfiguration",
+          "children": [
+            {
+              "id": "excessively_privileged_user_dba",
+              "cwe": ["CWE-250"]
+            }
+          ]
+        },
+        {
+          "id": "lack_of_password_confirmation",
+          "children": [
+            {
+              "id": "change_password",
+              "cwe": ["CWE-620"]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/sample_vrt/2.0/mappings/remediation_advice.json
+++ b/spec/sample_vrt/2.0/mappings/remediation_advice.json
@@ -1,0 +1,32 @@
+{
+  "metadata": {
+    "default": null,
+    "keys": ["remediation_advice", "references"]
+  },
+  "content": [
+    {
+      "id": "server_security_misconfiguration",
+      "references": [
+        "https://www.owasp.org/index.php/Top_10_2013-A5-Security_Misconfiguration",
+        "http://projects.webappsec.org/w/page/13246959/Server%20Misconfiguration"
+      ],
+      "children": [
+        {
+          "id": "unsafe_cross_origin_resource_sharing",
+          "remediation_advice": "This is advice",
+          "references": [
+            "https://www.owasp.org/index.php/HTML5_Security_Cheat_Sheet#Cross_Origin_Resource_Sharing",
+            "https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS"
+          ]
+        },
+        {
+          "id": "directory_listing_enabled",
+          "remediation_advice": "Restrict directory listings being displayed from the server configuration.  \n\nExample for Apache:\n\n1. Edit the server configuration file or edit/create directory .htaccess\n2. Add the following line:\nOptions -Indexes\n3. If it is the last line, make sure you have a new line after it.",
+          "references": [
+            "http://projects.webappsec.org/w/page/13246922/Directory%20Indexing"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/sample_vrt/2.0/mappings/remediation_advice.json
+++ b/spec/sample_vrt/2.0/mappings/remediation_advice.json
@@ -25,6 +25,33 @@
           "references": [
             "http://projects.webappsec.org/w/page/13246922/Directory%20Indexing"
           ]
+        },
+        {
+          "id": "misconfigured_dns",
+          "children": [
+            {
+              "id": "subdomain_takeover",
+              "remediation_advice": "1. Set up your external service so it fully listens to your wildcard DNS.\n2. Keep your DNS-entries constantly vetted and restricted.",
+              "references": [
+                "https://labs.detectify.com/2014/10/21/hostile-subdomain-takeover-using-herokugithubdesk-more/"
+              ]
+            },
+            {
+              "id": "zone_transfer",
+              "remediation_advice": "Do not allow DNS zone transfers.",
+              "references": [
+                "https://www.sans.org/reading-room/whitepapers/dns/securing-dns-zone-transfer-868",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-1999-0532"
+              ]
+            },
+            {
+              "id": "missing_caa_record",
+              "remediation_advice": "As the domain name holder you can modify the DNS zone file to specify one or more Certification Authorities (CAs) authorized to issue certificates for that domain.",
+              "references": [
+                "https://tools.ietf.org/html/rfc6844"
+              ]
+            }
+          ]
         }
       ]
     }

--- a/spec/sample_vrt/999.999/mappings/cwe.json
+++ b/spec/sample_vrt/999.999/mappings/cwe.json
@@ -1,0 +1,60 @@
+{
+  "metadata": {
+    "default": ["CWE-2000"]
+  },
+  "content": [
+    {
+      "id": "server_security_misconfiguration",
+      "cwe": ["CWE-933"],
+      "children": [
+        {
+          "id": "unsafe_cross_origin_resource_sharing",
+          "cwe": ["CWE-942"]
+        },
+        {
+          "id": "path_traversal",
+          "cwe": ["CWE-22", "CWE-73"]
+        },
+        {
+          "id": "directory_listing_enabled",
+          "cwe": ["CWE-548"]
+        },
+        {
+          "id": "ssl_attack_breach_poodle_etc",
+          "cwe": ["CWE-310"]
+        },
+        {
+          "id": "using_default_credentials",
+          "cwe": ["CWE-255", "CWE-521"]
+        },
+        {
+          "id": "misconfigured_dns",
+          "children": [
+            {
+              "id": "zone_transfer",
+              "cwe": ["CWE-669"]
+            }
+          ]
+        },
+        {
+          "id": "dbms_misconfiguration",
+          "children": [
+            {
+              "id": "excessively_privileged_user_dba",
+              "cwe": ["CWE-250"]
+            }
+          ]
+        },
+        {
+          "id": "lack_of_password_confirmation",
+          "children": [
+            {
+              "id": "change_password",
+              "cwe": ["CWE-620"]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/sample_vrt/999.999/mappings/remediation_advice.json
+++ b/spec/sample_vrt/999.999/mappings/remediation_advice.json
@@ -1,0 +1,32 @@
+{
+  "metadata": {
+    "default": null,
+    "keys": ["remediation_advice", "references"]
+  },
+  "content": [
+    {
+      "id": "server_security_misconfiguration",
+      "references": [
+        "https://www.owasp.org/index.php/Top_10_2013-A5-Security_Misconfiguration",
+        "http://projects.webappsec.org/w/page/13246959/Server%20Misconfiguration"
+      ],
+      "children": [
+        {
+          "id": "unsafe_cross_origin_resource_sharing",
+          "remediation_advice": "This is advice",
+          "references": [
+            "https://www.owasp.org/index.php/HTML5_Security_Cheat_Sheet#Cross_Origin_Resource_Sharing",
+            "https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS"
+          ]
+        },
+        {
+          "id": "directory_listing_enabled",
+          "remediation_advice": "Restrict directory listings being displayed from the server configuration.  \n\nExample for Apache:\n\n1. Edit the server configuration file or edit/create directory .htaccess\n2. Add the following line:\nOptions -Indexes\n3. If it is the last line, make sure you have a new line after it.",
+          "references": [
+            "http://projects.webappsec.org/w/page/13246922/Directory%20Indexing"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/sample_vrt/999.999/mappings/remediation_advice.json
+++ b/spec/sample_vrt/999.999/mappings/remediation_advice.json
@@ -25,6 +25,33 @@
           "references": [
             "http://projects.webappsec.org/w/page/13246922/Directory%20Indexing"
           ]
+        },
+        {
+          "id": "misconfigured_dns",
+          "children": [
+            {
+              "id": "subdomain_takeover",
+              "remediation_advice": "1. Set up your external service so it fully listens to your wildcard DNS.\n2. Keep your DNS-entries constantly vetted and restricted.",
+              "references": [
+                "https://labs.detectify.com/2014/10/21/hostile-subdomain-takeover-using-herokugithubdesk-more/"
+              ]
+            },
+            {
+              "id": "zone_transfer",
+              "remediation_advice": "Do not allow DNS zone transfers.",
+              "references": [
+                "https://www.sans.org/reading-room/whitepapers/dns/securing-dns-zone-transfer-868",
+                "https://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-1999-0532"
+              ]
+            },
+            {
+              "id": "missing_caa_record",
+              "remediation_advice": "As the domain name holder you can modify the DNS zone file to specify one or more Certification Authorities (CAs) authorized to issue certificates for that domain.",
+              "references": [
+                "https://tools.ietf.org/html/rfc6844"
+              ]
+            }
+          ]
         }
       ]
     }

--- a/spec/vrt/mappings_spec.rb
+++ b/spec/vrt/mappings_spec.rb
@@ -76,6 +76,57 @@ describe VRT::Mapping do
           is_expected.to eq('m')
         end
       end
+
+      context 'mapping with two keys' do
+        let(:advice) { described_class.new(:remediation_advice) }
+        let(:version) { '999.999' }
+
+        subject { advice.get(id_list, version) }
+
+        context 'when only one of the keys has values' do
+          let(:id_list) { %i[server_security_misconfiguration] }
+
+          it 'returns a hash with both mapping keys present' do
+            is_expected.to match a_hash_including(
+              remediation_advice: nil,
+              references: [
+                'https://www.owasp.org/index.php/Top_10_2013-A5-Security_Misconfiguration',
+                'http://projects.webappsec.org/w/page/13246959/Server%20Misconfiguration'
+              ]
+            )
+          end
+        end
+
+        context 'when both of the keys have values' do
+          let(:id_list) { %i[server_security_misconfiguration unsafe_cross_origin_resource_sharing] }
+
+          it 'returns a hash with both mapping keys and values present' do
+            is_expected.to match a_hash_including(
+              remediation_advice: 'This is advice',
+              references: [
+                'https://www.owasp.org/index.php/HTML5_Security_Cheat_Sheet#Cross_Origin_Resource_Sharing',
+                'https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS',
+                'https://www.owasp.org/index.php/Top_10_2013-A5-Security_Misconfiguration',
+                'http://projects.webappsec.org/w/page/13246959/Server%20Misconfiguration'
+              ]
+            )
+          end
+        end
+
+        context 'with arrays as the mapping values' do
+          let(:id_list) { %i[server_security_misconfiguration misconfigured_dns subdomain_takeover] }
+
+          it 'merges the arrays in order of variant -> subcategory -> category' do
+            is_expected.to match a_hash_including(
+              references: [
+                'https://labs.detectify.com/2014/10/21/hostile-subdomain-takeover-using-herokugithubdesk-more/',
+                'https://www.owasp.org/index.php/Top_10_2013-A5-Security_Misconfiguration',
+                'http://projects.webappsec.org/w/page/13246959/Server%20Misconfiguration'
+              ]
+            )
+          end
+        end
+      end
     end
   end
 end

--- a/spec/vrt/node_spec.rb
+++ b/spec/vrt/node_spec.rb
@@ -49,8 +49,31 @@ describe VRT::Node do
       expect(mappings.keys).to eq(VRT::MAPPINGS)
     end
 
-    it 'has the right values' do
-      expect(mappings).to include(cvss_v3: 'b')
+    context 'cvss_v3' do
+      it 'has the right values' do
+        expect(mappings).to include(cvss_v3: 'b')
+      end
+    end
+
+    context 'remediation_advice' do
+      let(:id) { 'server_security_misconfiguration.unsafe_cross_origin_resource_sharing' }
+
+      it 'has the expected remediation advice' do
+        expect(mappings[:remediation_advice]).to match hash_including(
+          remediation_advice: 'This is advice'
+        )
+      end
+
+      it 'has the expected (concatenated) references' do
+        expect(mappings[:remediation_advice]).to match hash_including(
+          references: [
+            'https://www.owasp.org/index.php/HTML5_Security_Cheat_Sheet#Cross_Origin_Resource_Sharing',
+            'https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS',
+            'https://www.owasp.org/index.php/Top_10_2013-A5-Security_Misconfiguration',
+            'http://projects.webappsec.org/w/page/13246959/Server%20Misconfiguration'
+          ]
+        )
+      end
     end
   end
 

--- a/spec/vrt/node_spec.rb
+++ b/spec/vrt/node_spec.rb
@@ -75,6 +75,16 @@ describe VRT::Node do
         )
       end
     end
+
+    context 'cwe' do
+      it 'has the exepected (concatenated) CWE IDs' do
+        expect(mappings[:cwe]).to eq [
+          'CWE-942',
+          'CWE-933',
+          'CWE-2000'
+        ]
+      end
+    end
   end
 
   describe '#as_json' do


### PR DESCRIPTION
This adds [VRT 1.4](https://github.com/bugcrowd/vulnerability-rating-taxonomy) and support for two new mappings released with VRT 1.4: [CWE](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe.json) and [Bugcrowd Remediation Advice](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice.json).

The code changes here (mostly by @tessereth) are to handle the new mappings which introduce two changes:

- When parsing a mapping, merging collections from lower VRT specificity with collections from higher VRT specificity. Concretely, the CWE for a top level category like `server_security_misconfiguration` (CWE-933) will be concatenated with the CWEs for more specific categories like `server_security_misconfiguration.path_traversal` (CWE-22, CWE-73). So when viewing the mapping for `server_security_misconfiguration.path_traversal` the value will be (CWE-22, CWE-73, CWE-933).

- Displaying sibling keys for a mapping (as specified in the `metadata` field in the mapping JSON) under a single mapping key. Concretely, the two remediation advice keys (`references`, and `remediation_advice`) are available under a single `remediation_advice` key.  i.e.
`{ remediation_advice: { remediation_advice: 'advice', references: [...] }` 

~This also bumps the version to 0.5.0~

~Should I add a changelog entry as part of this branch?~