### PR TITLE
Release v0.5.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vrt (0.4.6)
+    vrt (0.5.6)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/vrt/version.rb
+++ b/lib/vrt/version.rb
@@ -1,3 +1,3 @@
 module Vrt
-  VERSION = '0.4.6'.freeze
+  VERSION = '0.5.6'.freeze
 end


### PR DESCRIPTION
From the changelog, this release consists of:

**Added**
VRT 1.4 data
Support for mappings with keys metadata
CWE mapping
Bugcrowd Remediation Advice mapping

**Changed**
Mappings with array values now coalesce downwards. Child VRT nodes will include values from parent nodes if a mapping provides node data as an array.

I'm assuming we want to hold off on updating the changelog for this release until we actually push the tag and release to ruby gems? Otherwise I can do it in this PR.