### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
+
+### Changed
+
+### Removed
+
+## [v0.5.0](https://github.com/bugcrowd/vrt-ruby/compare/v0.4.6...v0.5.0) - 2018-05-01
+### Added
 - VRT 1.4 data
 - Support for mappings with `keys` metadata
 - CWE mapping

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vrt (0.4.6)
+    vrt (0.5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/vrt/version.rb
+++ b/lib/vrt/version.rb
@@ -1,3 +1,3 @@
 module Vrt
-  VERSION = '0.4.6'.freeze
+  VERSION = '0.5.0'.freeze
 end


### PR DESCRIPTION
### Added
 - VRT 1.4 data
 - Support for mappings with `keys` metadata
 - CWE mapping
 - Bugcrowd Remediation Advice mapping
 
 ### Changed
 - Mappings with array values now caolesce downwards.
   Child VRT nodes will include values from parent nodes if a mapping
   provides node data as an array.
 
(The link in the changelog won't work until we tag the release)