### PR TITLE
Add convenience method

### DIFF
--- a/lib/vrt.rb
+++ b/lib/vrt.rb
@@ -86,6 +86,12 @@ module VRT
     end
   end
 
+  # Convenience method to easily get the most current or preferred version of a vrt_id
+  def correct_vrt_id(vrt_id, version = current_version)
+    find_node(vrt_id: vrt_id, preferred_version: version)
+      .qualified_vrt_id
+  end
+
   # Load the VRT from text files, and parse it as JSON.
   # If other: true, we append the OTHER_OPTION hash at runtime (not cached)
   def get_json(version: nil, other: true)

--- a/spec/vrt_spec.rb
+++ b/spec/vrt_spec.rb
@@ -178,6 +178,17 @@ describe VRT do
     end
   end
 
+  describe '#correct_vrt_id' do
+    subject(:correct_vrt) { described_class.correct_vrt_id(vrt_id, version) }
+
+    let(:vrt_id) { 'server_security_misconfiguration.unsafe_cross_origin_resource_sharing.critical_impact' }
+    let(:version) { '999.999' }
+
+    it 'returns the correct qualified_vrt_id' do
+      is_expected.to eq 'server_security_misconfiguration.unsafe_cross_origin_resource_sharing'
+    end
+  end
+
   describe '#all_matching_categories' do
     subject(:full_search_list) { described_class.all_matching_categories(categories) }
 

--- a/spec/vrt_spec.rb
+++ b/spec/vrt_spec.rb
@@ -181,11 +181,20 @@ describe VRT do
   describe '#correct_vrt_id' do
     subject(:correct_vrt) { described_class.correct_vrt_id(vrt_id, version) }
 
-    let(:vrt_id) { 'server_security_misconfiguration.unsafe_cross_origin_resource_sharing.critical_impact' }
-    let(:version) { '999.999' }
+    let(:vrt_id) { 'unvalidated_redirects_and_forwards.open_redirect.get_based_authenticated' }
+    let(:version) { '2.0' }
 
     it 'returns the correct qualified_vrt_id' do
-      is_expected.to eq 'server_security_misconfiguration.unsafe_cross_origin_resource_sharing'
+      is_expected.to eq 'unvalidated_redirects_and_forwards.open_redirect.get_based'
+    end
+
+    context 'when no version is passed' do
+      let(:vrt_id) { 'server_security_misconfiguration.unsafe_cross_origin_resource_sharing.critical_impact' }
+      let(:version) { nil }
+
+      it 'defaults to the latest version' do
+        is_expected.to eq 'server_security_misconfiguration.unsafe_cross_origin_resource_sharing'
+      end
     end
   end
 


### PR DESCRIPTION
This provides a shorthand way of getting the version corrected vrt_id.

We do this a lot in dependent applications and it seems to make sense for the gem to do it.