### PR TITLE
Add condition to not merge arrays with default

### DIFF
--- a/lib/vrt/mapping.rb
+++ b/lib/vrt/mapping.rb
@@ -72,15 +72,15 @@ module VRT
       id_list.each do |id|
         entry = mapping[id]
         break unless entry # mapping file doesn't go this deep, return previous value
-        best_guess = merge_arrays(best_guess, entry[key]) if entry[key]
+        best_guess = merge_arrays(best_guess, entry[key], default) if entry[key]
         # use the children mapping for the next iteration
         mapping = entry['children'] || {}
       end
       best_guess
     end
 
-    def merge_arrays(previous_value, new_value)
-      if previous_value.is_a?(Array) && new_value.is_a?(Array)
+    def merge_arrays(previous_value, new_value, default = nil)
+      if previous_value.is_a?(Array) && new_value.is_a?(Array) && previous_value != default
         new_value | previous_value
       else
         new_value

--- a/lib/vrt/mapping.rb
+++ b/lib/vrt/mapping.rb
@@ -68,19 +68,19 @@ module VRT
     def get_key(id_list:, mapping:, key:, default:)
       # iterate through the id components, keeping track of where we are in the mapping file
       # and the most specific mapped value found so far
-      best_guess = default
+      best_guess = nil
       id_list.each do |id|
         entry = mapping[id]
         break unless entry # mapping file doesn't go this deep, return previous value
-        best_guess = merge_arrays(best_guess, entry[key], default) if entry[key]
+        best_guess = merge_arrays(best_guess, entry[key]) if entry[key]
         # use the children mapping for the next iteration
         mapping = entry['children'] || {}
       end
-      best_guess
+      best_guess || default
     end
 
-    def merge_arrays(previous_value, new_value, default = nil)
-      if previous_value.is_a?(Array) && new_value.is_a?(Array) && previous_value != default
+    def merge_arrays(previous_value, new_value)
+      if previous_value.is_a?(Array) && new_value.is_a?(Array)
         new_value | previous_value
       else
         new_value

--- a/lib/vrt/mapping.rb
+++ b/lib/vrt/mapping.rb
@@ -26,12 +26,11 @@ module VRT
           acc[key.to_sym] = get_key(
             id_list: id_list,
             mapping: mapping,
-            key: key,
-            default: default&.try(:[], key)
-          )
+            key: key
+          ) || default&.try(:[], key)
         end
       else
-        get_key(id_list: id_list, mapping: mapping, key: @scheme, default: default)
+        get_key(id_list: id_list, mapping: mapping, key: @scheme) || default
       end
     end
 
@@ -65,7 +64,7 @@ module VRT
       end
     end
 
-    def get_key(id_list:, mapping:, key:, default:)
+    def get_key(id_list:, mapping:, key:)
       # iterate through the id components, keeping track of where we are in the mapping file
       # and the most specific mapped value found so far
       best_guess = nil
@@ -76,7 +75,7 @@ module VRT
         # use the children mapping for the next iteration
         mapping = entry['children'] || {}
       end
-      best_guess || default
+      best_guess
     end
 
     def merge_arrays(previous_value, new_value)

--- a/spec/vrt/mappings_spec.rb
+++ b/spec/vrt/mappings_spec.rb
@@ -127,6 +127,27 @@ describe VRT::Mapping do
           end
         end
       end
+
+      context 'with arrays as the mapping values' do
+        subject { described_class.new(:cwe).get(id_list, version) }
+        let(:version) { '999.999' }
+
+        context 'when mapping has a default' do
+          let(:id_list) { %i[server_security_misconfiguration] }
+
+          it 'does NOT include the default mapping value' do
+            is_expected.to contain_exactly('CWE-933')
+          end
+
+          context 'no mapping exists' do
+            let(:id_list) { %i[other] }
+
+            it 'only includes the default mapping value' do
+              is_expected.to contain_exactly('CWE-2000')
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/vrt/node_spec.rb
+++ b/spec/vrt/node_spec.rb
@@ -80,8 +80,7 @@ describe VRT::Node do
       it 'has the exepected (concatenated) CWE IDs' do
         expect(mappings[:cwe]).to eq [
           'CWE-942',
-          'CWE-933',
-          'CWE-2000'
+          'CWE-933'
         ]
       end
     end


### PR DESCRIPTION
I spotted some issues with CWE mapping and the default:

1. The default in CWE should be removed since it represents a general table of contents and in no way is a default value for a mapping.  A good example of a default value is in the CVSS mapping.

2. If a mapping consists of arrays that will be merged, we should not merge the default in with every array.

The first issue is an upstream change that must be made to the VRT itself.  PR here: https://github.com/bugcrowd/vulnerability-rating-taxonomy/pull/162

The second issue is fixed by this pr.  Now the default is only used when no other mapping exists.  This way the default doesn't pollute every single value returned by the merged array mapping.