### PR TITLE
Vrt v1.6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "lib/data/1.5"]
 	path = lib/data/1.5
 	url = git@github.com:bugcrowd/vulnerability-rating-taxonomy.git
+[submodule "lib/data/1.6"]
+	path = lib/data/1.6
+	url = git@github.com:bugcrowd/vulnerability-rating-taxonomy.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Removed
 
-## [v0.6.0](https://github.com/bugcrowd/vrt-ruby/compare/v0.5.1...v0.6.0) - 2018-09-27
+## [v0.7.0](https://github.com/bugcrowd/vrt-ruby/compare/v0.6.0...v0.7.0) - 2018-11-05
 ### Added
+- Support for VRT v1.6
 
+## [v0.6.0](https://github.com/bugcrowd/vrt-ruby/compare/v0.5.1...v0.6.0) - 2018-09-27
 ### Changed
 - Fixed bug for mappings with multiple keys and a default (resolves: [#26](https://github.com/bugcrowd/vrt-ruby/issues/26))
 


### PR DESCRIPTION
# Description

Updates latest available version of VRT to [v1.6](https://github.com/bugcrowd/vulnerability-rating-taxonomy/releases/tag/v1.6)

# Checklist:

- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
- [x] I have not incremented `version.rb`
