### PR TITLE
Recurse through deprecated mapping until a node is found

### DIFF
--- a/lib/vrt/cross_version_mapping.rb
+++ b/lib/vrt/cross_version_mapping.rb
@@ -32,7 +32,8 @@ module VRT
     def find_deprecated_node(vrt_id, new_version = nil, max_depth = 'variant')
       version = latest_version_for_deprecated_node(vrt_id)
       node_id = deprecated_node_json[vrt_id][new_version] || deprecated_node_json[vrt_id][version]
-      VRT::Map.new(new_version).find_node(node_id, max_depth: max_depth)
+      new_node = VRT::Map.new(new_version).find_node(node_id, max_depth: max_depth)
+      new_node.nil? ? find_deprecated_node(node_id, new_version, max_depth) : new_node
     end
 
     def find_valid_parent_node(vrt_id, new_version, max_depth)

--- a/spec/sample_vrt/999.999/deprecated-node-mapping.json
+++ b/spec/sample_vrt/999.999/deprecated-node-mapping.json
@@ -6,14 +6,16 @@
     "2.0": "other"
   },
   "unvalidated_redirects_and_forwards.open_redirect.get_based_all_users": {
-    "2.0": "unvalidated_redirects_and_forwards.open_redirect.get_based_thingo",
-    "999.999": "unvalidated_redirects_and_forwards.open_redirect.get_based"
+    "2.0": "unvalidated_redirects_and_forwards.open_redirect.get_based_thingo"
   },
   "unvalidated_redirects_and_forwards.open_redirect.get_based_authenticated": {
     "2.0": "unvalidated_redirects_and_forwards.open_redirect.get_based"
   },
   "unvalidated_redirects_and_forwards.open_redirect.get_based_unauthenticated": {
     "2.0": "unvalidated_redirects_and_forwards.open_redirect.get_based"
+  },
+  "unvalidated_redirects_and_forwards.open_redirect.get_based_thingo" : {
+    "999.999": "unvalidated_redirects_and_forwards.open_redirect.get_based"
   },
   "unvalidated_redirects_and_forwards.lack_of_security_speed_bump_page": {
     "999.999": "external_behavior.lack_of_security_speed_bump_page"

--- a/spec/vrt_spec.rb
+++ b/spec/vrt_spec.rb
@@ -175,6 +175,15 @@ describe VRT do
           expect(found_node).to be_nil
         end
       end
+
+      context 'when found node is also deprecated' do
+        let(:vrt_id) { 'unvalidated_redirects_and_forwards.open_redirect.get_based_all_users' }
+        let(:new_version) { '999.999' }
+
+        it 'should retrieve the deeply nested deprecated mapping' do
+          expect(found_node.qualified_vrt_id).to eq 'unvalidated_redirects_and_forwards.open_redirect.get_based'
+        end
+      end
     end
   end
 
@@ -212,6 +221,7 @@ describe VRT do
           unvalidated_redirects_and_forwards.open_redirect.get_based_all_users
           unvalidated_redirects_and_forwards.open_redirect.get_based_unauthenticated
           unvalidated_redirects_and_forwards.open_redirect.get_based_authenticated
+          unvalidated_redirects_and_forwards.open_redirect.get_based_thingo
         ]
       end
 


### PR DESCRIPTION
# Description

Fixes the following runtime error: https://app.bugsnag.com/bugcrowd/crowdcontrol/errors/5bfd9523ef606f00187878dc?event_id=5bfd952300308faaf9b30000&i=sk&m=nw

Initially we assumed that the deprecated mapping would be filled out for chains of deprecations where a single deprecated version would have multiple entries if it's mapping also changed in a subsequent version.  That is however annoying for the ASE team to maintain when deprecating vrt entries.

Now when searching for the deprecated node, we recurse until it is found.

# Checklist:

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
- [x] I have not incremented `version.rb`
