### PR TITLE
Add spec to ensure we allow a vrt_id to start with a number

### DIFF
--- a/lib/vrt/map.rb
+++ b/lib/vrt/map.rb
@@ -41,8 +41,11 @@ module VRT
     private
 
     def valid_identifier?(vrt_id)
-      # At least one string of lowercase letters, numbers, or _, plus up to 2 more with stops
-      @_valid_identifiers[vrt_id] ||= vrt_id =~ /other|\A[a-z_\d]+(\.[a-z_\d]+){0,2}\z/
+      # The upstream json schema in the VRT has changed so we need to support both:
+      # Current: At least one string of lowercase letters or _, plus up to 2 more with stops (no digits)
+      # and Old: At least one string of lowercase letters, numbers, or _,
+      #          plus up to 2 more with stops and no leading numbers
+      @_valid_identifiers[vrt_id] ||= vrt_id =~ /other|\A[a-z][a-z_\d]*(\.[a-z][a-z_\d]*){0,2}\z/
     end
 
     def construct_lineage(string, max_depth)

--- a/lib/vrt/map.rb
+++ b/lib/vrt/map.rb
@@ -41,7 +41,7 @@ module VRT
     private
 
     def valid_identifier?(vrt_id)
-      # At least one string of lowercase alphanumeric or _, plus up to 2 more with stops
+      # At least one string of lowercase letters, numbers, or _, plus up to 2 more with stops
       @_valid_identifiers[vrt_id] ||= vrt_id =~ /other|\A[a-z_\d]+(\.[a-z_\d]+){0,2}\z/
     end
 

--- a/lib/vrt/map.rb
+++ b/lib/vrt/map.rb
@@ -41,7 +41,7 @@ module VRT
     private
 
     def valid_identifier?(vrt_id)
-      # At least one string of lowercase or _, plus up to 2 more with stops
+      # At least one string of lowercase alphanumeric or _, plus up to 2 more with stops
       @_valid_identifiers[vrt_id] ||= vrt_id =~ /other|\A[a-z_\d]+(\.[a-z_\d]+){0,2}\z/
     end
 

--- a/spec/sample_vrt/999.999/vulnerability-rating-taxonomy.json
+++ b/spec/sample_vrt/999.999/vulnerability-rating-taxonomy.json
@@ -392,6 +392,13 @@
       ]
     },
     {
+      "id": "2fa_example",
+      "name": "2FA Example Vuln",
+      "type": "category",
+      "priority": 4,
+      "children": []
+    },
+    {
       "id": "server_side_injection",
       "name": "Server-Side Injection",
       "type": "category",

--- a/spec/sample_vrt/999.999/vulnerability-rating-taxonomy.json
+++ b/spec/sample_vrt/999.999/vulnerability-rating-taxonomy.json
@@ -399,6 +399,12 @@
       "children": []
     },
     {
+      "id": "f",
+      "name": "Short id example",
+      "type": "category",
+      "priority": null
+    },
+    {
       "id": "server_side_injection",
       "name": "Server-Side Injection",
       "type": "category",

--- a/spec/vrt/map_spec.rb
+++ b/spec/vrt/map_spec.rb
@@ -100,8 +100,14 @@ describe VRT::Map do
       it { is_expected.to be_truthy }
     end
 
-    context 'with invalid string' do
-      let(:string) { '12112asdas2312dcdwsdf-^?' }
+    context 'with numeric in front' do
+      let(:string) { '2fa_example' }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'with invalid characters' do
+      let(:string) { 'a12112asdas2312dcdwsdf-^?' }
 
       it { is_expected.to be_falsey }
     end

--- a/spec/vrt/map_spec.rb
+++ b/spec/vrt/map_spec.rb
@@ -103,6 +103,12 @@ describe VRT::Map do
     context 'with numeric in front' do
       let(:string) { '2fa_example' }
 
+      it { is_expected.to be_falsey }
+    end
+
+    context 'super short' do
+      let(:string) { 'f' }
+
       it { is_expected.to be_truthy }
     end
 


### PR DESCRIPTION
# Description

We already allow `\d` or `[0-9]` in the regex here so this just updates the comment and tests to better reflect that.

# Checklist:

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] ~I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed~ (no change in functionality)
- [x] I have not incremented `version.rb`
