### PR TITLE
Update rubocop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,6 @@ task default: :spec
 desc 'Override our build task to ensure VRT git submodules are present'
 task 'build' do
   submodule_status = `git submodule init && git submodule update`
-  unless submodule_status.empty?
-    raise 'git submodules were not up-to-date. Please rebuild!'
-  end
+
+  raise 'git submodules were not up-to-date. Please rebuild!' unless submodule_status.empty?
 end

--- a/lib/generators/vrt/install_generator.rb
+++ b/lib/generators/vrt/install_generator.rb
@@ -3,7 +3,7 @@ require 'rails/generators/base'
 module Vrt
   module Generators
     class InstallGenerator < Rails::Generators::Base
-      source_root(File.expand_path(File.dirname(__FILE__)))
+      source_root(File.expand_path(File.dirname(__dir__)))
       def create_initializer_file
         copy_file '../vrt.rb', 'config/initializers/vrt.rb'
       end

--- a/lib/vrt.rb
+++ b/lib/vrt.rb
@@ -48,6 +48,7 @@ module VRT
   def last_updated(version = nil)
     version ||= current_version
     return @last_update[version] if @last_update[version]
+
     metadata = JSON.parse(json_pathname(version).read)['metadata']
     @last_update[version] = Date.parse(metadata['release_date'])
   end

--- a/lib/vrt/cross_version_mapping.rb
+++ b/lib/vrt/cross_version_mapping.rb
@@ -5,7 +5,7 @@ module VRT
     def cross_version_category_mapping
       category_map = {}
       deprecated_node_json.each do |key, value|
-        latest_version = value.keys.sort_by { |n| Gem::Version.new(n) }.last
+        latest_version = value.keys.max_by { |n| Gem::Version.new(n) }
         id_list = value[latest_version].split('.')
         cat_id = id_list[0]
         sub_id = id_list[0..1].join('.')
@@ -26,7 +26,7 @@ module VRT
     end
 
     def latest_version_for_deprecated_node(vrt_id)
-      deprecated_node_json[vrt_id].keys.sort_by { |n| Gem::Version.new(n) }.last
+      deprecated_node_json[vrt_id].keys.max_by { |n| Gem::Version.new(n) }
     end
 
     def find_deprecated_node(vrt_id, new_version = nil, max_depth = 'variant')
@@ -43,6 +43,7 @@ module VRT
       else
         parent = vrt_id.split('.')[0..-2].join('.')
         return nil if parent.empty?
+
         find_valid_parent_node(parent, new_version, max_depth)
       end
     end

--- a/lib/vrt/map.rb
+++ b/lib/vrt/map.rb
@@ -47,9 +47,11 @@ module VRT
 
     def construct_lineage(string, max_depth)
       return unless valid_identifier?(string)
+
       lineage = ''
       walk_node_tree(string, max_depth: max_depth) do |ids, node, level|
         return unless node
+
         lineage += node.name
         lineage += ' > ' unless level == ids.length
       end
@@ -79,9 +81,7 @@ module VRT
 
     def build_node(memo, vrt, parent = nil)
       node = Node.new(vrt.merge('version' => @version, 'parent' => parent))
-      if node.children?
-        node.children = vrt['children'].reduce({}) { |m, v| build_node(m, v, node) }
-      end
+      node.children = vrt['children'].reduce({}) { |m, v| build_node(m, v, node) } if node.children?
       memo[node.id] = node
       memo
     end

--- a/lib/vrt/mapping.rb
+++ b/lib/vrt/mapping.rb
@@ -41,6 +41,7 @@ module VRT
       VRT.versions.each do |version|
         filename = VRT::DIR.join(version, 'mappings', "#{@scheme}.json")
         next unless File.file?(filename)
+
         mapping = JSON.parse(File.read(filename))
         mapping['content'] = key_by_id(mapping['content'])
         @mappings[version] = mapping
@@ -71,6 +72,7 @@ module VRT
       id_list.each do |id|
         entry = mapping[id]
         break unless entry # mapping file doesn't go this deep, return previous value
+
         best_guess = merge_arrays(best_guess, entry[key]) if entry[key]
         # use the children mapping for the next iteration
         mapping = entry['children'] || {}

--- a/vrt.gemspec
+++ b/vrt.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '0.56.0'
 end

--- a/vrt.gemspec
+++ b/vrt.gemspec
@@ -1,6 +1,4 @@
-# coding: utf-8
-
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'date'
 require 'vrt/version'
@@ -19,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop', '0.48.1'
-  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rubocop'
 end

--- a/vrt.gemspec
+++ b/vrt.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
+  # TODO: investigate why rubocop's jaro-winkler dependency fails to install in our alpine linux image
   spec.add_development_dependency 'rubocop', '0.56.0'
 end


### PR DESCRIPTION
# Description

Child PR: https://github.com/bugcrowd/vrt-ruby/pull/42

Update rubocop so we can upgrade ruby version.
After rubocop 0.56.0 they introduce the dependency `jaro-winkler` which fails to install in our alpine image: https://buildkite.com/bugcrowd-inc/vrt-ruby/builds/16#b6f453c4-ab01-45f6-8f02-088becc0d3b2

<img width="532" alt="screen shot 2019-02-15 at 12 46 27 pm" src="https://user-images.githubusercontent.com/1854876/52883431-bdd34e80-311f-11e9-8c56-8d0a4a50359a.png">

# Checklist:

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
- [x] I have not incremented `version.rb`
