### PR TITLE
Add vrt version 1.8

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "lib/data/1.7.1"]
 	path = lib/data/1.7.1
 	url = git@github.com:bugcrowd/vulnerability-rating-taxonomy.git
+[submodule "lib/data/1.8"]
+	path = lib/data/1.8
+	url = git@github.com:bugcrowd/vulnerability-rating-taxonomy.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
+- Support for VRT 1.8
 
 ### Changed
 


### PR DESCRIPTION
# Description

Adds support for VRT 1.8 release: https://github.com/bugcrowd/vulnerability-rating-taxonomy/releases/tag/v1.8

# Checklist:

- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
- [x] I have not incremented `version.rb`
