### PR TITLE
Add vrt version 1.9 to data

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "lib/data/1.8"]
 	path = lib/data/1.8
 	url = git@github.com:bugcrowd/vulnerability-rating-taxonomy.git
+[submodule "lib/data/1.9"]
+	path = lib/data/1.9
+	url = git@github.com:bugcrowd/vulnerability-rating-taxonomy.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
+- Support for VRT 1.9
 
 ### Changed
 


### PR DESCRIPTION
# Description

VRT 1.9 has been released so that means the gem will be going to 0.10.0
This pr just pulls in the new version json and updates the changelog

# Checklist:

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
- [x] I have not incremented `version.rb`
