### PR TITLE
Update changelog 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 - Support for VRT 1.9
 
-### Changed
-
-### Removed
-
 ## [v0.9.0](https://github.com/bugcrowd/vrt-ruby/compare/v0.8.1...v0.9.0) - 2019-10-04
 ### Added
 - Support for VRT 1.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
+
+### Changed
+
+### Removed
+
+## [v0.10.0](https://github.com/bugcrowd/vrt-ruby/compare/v0.9.0...v0.10.0) - 2020-07-09
+### Added
 - Support for VRT 1.9
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,11 @@ When a new version of the VRT is released, we follow these steps:
 ### Releasing new versions of the gem
 1. Merge all PRs targeted for inclusion in the release (without touching `version.rb`)
 2. Bump the version in `version.rb`
-3. Commit the version bump `git commit -m [tag name]` (where `tag name` is something like `v0.8.0`)
-4. Tag the commit `git tag [tag name]` (where `tag name` is something like `v0.8.0`)
-5. Push the tag and the commit `git push origin master --tag` 
-6. Run `rake release`
+3. Update CHANGELOG with new version
+4. Commit the version bump `git commit -m [tag name]` (where `tag name` is something like `v0.8.0`)
+5. Tag the commit `git tag [tag name]` (where `tag name` is something like `v0.8.0`)
+6. Push the tag and the commit `git push origin master --tag` 
+7. Run `rake release`
 
 
 If you need access to push the gem, create an account on rubygems (if you don't have one already) and then ask one of the existing owners to run `gem owner vrt --add <your-rubygems-email>`

--- a/vrt.gemspec
+++ b/vrt.gemspec
@@ -23,4 +23,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.6'
   # TODO: investigate why rubocop's jaro-winkler dependency fails to install in our alpine linux image
   spec.add_development_dependency 'rubocop', '0.56.0'
+  spec.metadata = {
+    'homepage_uri' => 'https://github.com/bugcrowd/vrt-ruby',
+    'changelog_uri' => 'https://github.com/bugcrowd/vrt-ruby/blob/master/CHANGELOG.md',
+    'source_code_uri' => 'https://github.com/bugcrowd/vrt-ruby',
+    'bug_tracker_uri' => 'https://github.com/bugcrowd/vrt-ruby/issues'
+  }
 end


### PR DESCRIPTION
# Description

I forgot to update the changelog when bumping the version release.  This pr:
- adds the necessary changelog entries
- adds a reminder to the contrib section
- adds some metadata to the gemspec

# Checklist:

- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
- [x] I have not incremented `version.rb`
