### PR TITLE
add ability to get lineage as array

### DIFF
--- a/lib/vrt/map.rb
+++ b/lib/vrt/map.rb
@@ -25,8 +25,9 @@ module VRT
       @_valid_vrt_ids[vrt_id] ||= valid_identifier?(vrt_id) && !find_node(vrt_id).nil?
     end
 
-    def get_lineage(string, max_depth: 'variant')
-      @_lineages[string + max_depth] ||= construct_lineage(string, max_depth)
+    def get_lineage(string, max_depth: 'variant', stringify: true)
+      @_lineages[string + max_depth + (stringify ? 'stringfied' : '')] ||=
+        stringify ? construct_lineage(string, max_depth).join(' > ') : construct_lineage(string, max_depth)
     end
 
     # Returns list of top level categories in the shape:
@@ -51,12 +52,11 @@ module VRT
     def construct_lineage(string, max_depth)
       return unless valid_identifier?(string)
 
-      lineage = ''
+      lineage = []
       walk_node_tree(string, max_depth: max_depth) do |ids, node, level|
         return unless node
 
-        lineage += node.name
-        lineage += ' > ' unless level == ids.length
+        lineage << node.name
       end
       lineage
     end

--- a/spec/vrt/map_spec.rb
+++ b/spec/vrt/map_spec.rb
@@ -68,9 +68,25 @@ describe VRT::Map do
           )
         end
 
+        context 'and not stringfied' do
+          it 'returns an array of categories with correct max depth' do
+            expect(sample_map.get_lineage(id, max_depth: 'subcategory', stringify: false)).to eq(
+              [ 'Server Security Misconfiguration (1.1)', 'Using Default Credentials']
+            )
+          end
+        end
+
         it 'returns a formatted lineage string with the correct max depth' do
           expect(sample_map.get_lineage(id, max_depth: 'category')).to eq(
             'Server Security Misconfiguration (1.1)'
+          )
+        end
+      end
+
+      context 'when requested not stringfied' do
+        it 'returns an array of categories' do
+          expect(sample_map.get_lineage(id, stringify: false)).to eq(
+            [ 'Server Security Misconfiguration (1.1)', 'Using Default Credentials', 'Production Server' ]
           )
         end
       end
@@ -81,6 +97,14 @@ describe VRT::Map do
 
       it 'returns a formatted lineage string' do
         expect(sample_map.get_lineage(id)).to eq 'Insecure Direct Object References (IDOR)'
+      end
+
+      context 'when requested not stringfied' do
+        it 'returns an array of with a single category' do
+          expect(sample_map.get_lineage(id, stringify: false )).to eq(
+            ['Insecure Direct Object References (IDOR)']
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
# Description

In CrowdControl we have some craziness because sometimes we need the lineage

`Server Security Misconfiguration (1.1) > Using Default Credentials`
as
```
<span>Server Security Misconfiguration (1.1)'</span>
<span>></span>
<span>Using Default Credentials</span>
```

It would be less crazy if we could 
```
get_lineage(vrt_id, stringify: false)
=> ['Server Security Misconfiguration (1.1)', 'Using Default Credentials']
```

# Checklist:

- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
- [ ] I have not incremented `version.rb`
