### PR TITLE
v1.16 changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,3 +64,6 @@
 [submodule "lib/data/1.15.1"]
 	path = lib/data/1.15.1
 	url = git@github.com:bugcrowd/vulnerability-rating-taxonomy.git
+[submodule "lib/data/1.16"]
+	path = lib/data/1.16
+	url = git@github.com:bugcrowd/vulnerability-rating-taxonomy.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Removed
 
+## [v0.13.5](https://github.com/bugcrowd/vrt-ruby/compare/v0.13.4...v0.13.5) - 2025-06-23
+
+### Added
+
+- Support for VRT 1.16
+
 ## [v0.13.4](https://github.com/bugcrowd/vrt-ruby/compare/v0.13.3...v0.13.4) - 2025-03-11
 
 ### Added

--- a/lib/vrt/version.rb
+++ b/lib/vrt/version.rb
@@ -1,3 +1,3 @@
 module Vrt
-  VERSION = '0.13.4'.freeze
+  VERSION = '0.13.5'.freeze
 end


### PR DESCRIPTION
# Description

Adding support for VRT v1.16.

For detailed changes refer to [this](https://github.com/bugcrowd/vulnerability-rating-taxonomy/pull/460).

# Testing

1. Clone the repo and checkout this branch. Then add this as a dependency in crowdcontrol's gemfile locally.
```shell
# Clear out existing vrt-ruby copy
git clone 'git....vrt-ruby'
cd vrt-ruby
git submodule update --init --recursive # This is needed to fetch all submodules.
```
```ruby
gem 'vrt', path: 'path/to/vrt-ruby'
```
2. Do the same for [templates](https://github.com/bugcrowd/templates) repo.
```ruby
gem 'bugcrowd_templates', path: 'path/to/templates'
```
3. Now restart the crowdcontrol server.
4. Login as a researcher and try submitting a report, in there check for the newly added VRT entries, those should be available there and their corresponding description should also be available.
5. Once submission is created head over to tracker side and for the newly created submission VRT version should be 1.16.

# Checklist:

- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
- [ ] I have not incremented `version.rb`