### PR TITLE
[PE-3456] VRT v1.19 Changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "lib/data/1.18"]
 	path = lib/data/1.18
 	url = git@github.com:bugcrowd/vulnerability-rating-taxonomy.git
+[submodule "lib/data/1.19"]
+	path = lib/data/1.19
+	url = git@github.com:bugcrowd/vulnerability-rating-taxonomy.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Removed
 
+## [v0.13.8](https://github.com/bugcrowd/vrt-ruby/compare/v0.13.7...v0.13.8) - 2026-06-24
+
+### Added
+
+- Support for VRT 1.19
+
 ## [v0.13.7](https://github.com/bugcrowd/vrt-ruby/compare/v0.13.6...v0.13.7) - 2026-03-09
 
 ### Added

--- a/lib/vrt/version.rb
+++ b/lib/vrt/version.rb
@@ -1,3 +1,3 @@
 module Vrt
-  VERSION = '0.13.7'.freeze
+  VERSION = '0.13.8'.freeze
 end


### PR DESCRIPTION
# Description

- Adding support for VRT v1.19.
- For detailed changes refer to [this](https://github.com/bugcrowd/vulnerability-rating-taxonomy/pull/508).

# Testing

1. Clone the repo and checkout this branch. Then add this as a dependency in crowdcontrol's gemfile locally.
```shell
# Clear out existing vrt-ruby copy
git clone 'git....vrt-ruby'
cd vrt-ruby
git submodule update --init --recursive # This is needed to fetch all submodules.
```
```ruby
gem 'vrt', path: 'path/to/vrt-ruby'
```
2. Do the same for [templates](https://github.com/bugcrowd/templates) repo.
```ruby
gem 'bugcrowd_templates', path: 'path/to/templates'
```
3. Now restart the crowdcontrol server.
4. Login as a researcher and try submitting a report, in there check for the newly added VRT entries, those should be available there and their corresponding description should also be available.
5. Once submission is created head over to tracker side and for the newly created submission VRT version should be 1.19.

# Checklist:

- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
- [ ] I have not incremented `version.rb`
